### PR TITLE
fix(subgraph): use hotfix version of graph-node 0.24

### DIFF
--- a/potion-protocol/docker-compose.yml
+++ b/potion-protocol/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   graph-node:
-    image: graphprotocol/graph-node:v0.24.1
+    image: graphprotocol/graph-node:v0.24.2
     ports:
       - "8000:8000"
       - "8001:8001"


### PR DESCRIPTION
graph-node 0.24.1 had an OOM bug that has been fixed in [graph-node 0.24.2](https://github.com/graphprotocol/graph-node/releases/tag/v0.24.2).
This problem is only related to local deployments and with big deploys (you will probably need a LOT of operations on pools/options to reach a point where it will actually matter) so it isn't particularly high priority to merge :smile: .